### PR TITLE
fix nil pointer dereference

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -76,12 +76,13 @@ func (*SQL) Open(database string, connectionString string) (*dbsql.DB, error) {
 // providing results as a slice of KeyValue instance(s) if available.
 func (*SQL) Query(db *dbsql.DB, query string, args ...interface{}) ([]KeyValue, error) {
 	rows, err := db.Query(query, args...)
-	defer func() {
-		_ = rows.Close()
-	}()
 	if err != nil {
 		return nil, err
 	}
+
+	defer func() {
+		_ = rows.Close()
+	}()
 	if rows.Err() != nil {
 		return nil, rows.Err()
 	}


### PR DESCRIPTION
Fix for the following, which I experienced while querying a PostreSQL DB that allowed limited(low) connections:
```
ERRO[0034] panic: runtime error: invalid memory address or nil pointer dereference
goroutine 811 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:24 +0x64
go.k6.io/k6/js/common.RunWithPanicCatching.func1()
	go.k6.io/k6@v0.43.1/js/common/util.go:82 +0x198
panic({0x101950b80, 0x102804690})
	runtime/panic.go:884 +0x204
github.com/dop251/goja.(*Runtime).runWrapped.func1()
	github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/runtime.go:2480 +0x168
panic({0x101950b80, 0x102804690})
	runtime/panic.go:884 +0x204
github.com/dop251/goja.(*vm).handleThrow(0x14002f027e0, {0x101950b80, 0x102804690})
	github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:730 +0x344
github.com/dop251/goja.(*vm).try.func1()
	github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:749 +0x48
panic({0x101950b80, 0x102804690})
	runtime/panic.go:884 +0x204
github.com/dop251/goja.(*vm).handleThrow(0x14002f027e0, {0x101950b80, 0x102804690})
	github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:730 +0x344
github.com/dop251/goja.(*vm).runTryInner.func1()
	github.com/dop251/goja@v0.0.0-20230128084908-78b980256d04/vm.go:772 +0x48
panic({0x101950b80, 0x102804690})
	runtime/panic.go:884 +0x204
database/sql.(*Rows).close(0x0, {0x0, 0x0})
	database/sql/sql.go:3274 +0x78
database/sql.(*Rows).Close(...)
	database/sql/sql.go:3270
github.com/grafana/xk6-sql.(*SQL).Query.func1()
	github.com/grafana/xk6-sql@v0.1.0/sql.go:80 +0x2c
github.com/grafana/xk6-sql.(*SQL).Query(0x7, 0x0?, {0x140080bba00?, 0x5?}, {0x102862808?, 0x100694ad8?, 0x2?})
	github.com/grafana/xk6-sql@v0.1.0/sql.go:83 +0x1b0
reflect.Value.call({0x1019798e0?, 0x14002727a40?, 0x12a4908b8?}, {0x10147f32d, 0x4}, {0x14008c231a0, 0x2, 0x0?})
	reflect/value.go:586 +0x87c
```

Which becomes a meaningful error after the fix in this PR
```
ERRO[0025] GoError: pq: remaining connection slots are reserved for non-replication superuser connections
running at reflect.methodValueCall (native)
default at insertedTimestampMs (file:///Users/asd/work/sandbox/k6/script.js:86:26(62))
	at file:///Users/asd/work/sandbox/k6/script.js:53:41(74)  executor=ramping-vus scenario=default source=stacktrace
``` 