### PR TITLE
Fixing mssql_test.js example with correct sp_executesql syntax

### DIFF
--- a/examples/mssql_test.js
+++ b/examples/mssql_test.js
@@ -19,7 +19,7 @@ export function teardown() {
 export default function () {
   db.exec("INSERT INTO keyvalues ([key], [value]) VALUES('plugin-name', 'k6-plugin-sql');");
 
-  let results = sql.query(db, "SELECT * FROM keyvalues WHERE key = @p1;", 'plugin-name');
+  let results = sql.query(db, "SELECT * FROM keyvalues WHERE [key] = @p1;", 'plugin-name');
   for (const row of results) {
     console.log(`key: ${row.key}, value: ${row.value}`);
   }

--- a/examples/mssql_test.js
+++ b/examples/mssql_test.js
@@ -19,7 +19,7 @@ export function teardown() {
 export default function () {
   db.exec("INSERT INTO keyvalues ([key], [value]) VALUES('plugin-name', 'k6-plugin-sql');");
 
-  let results = sql.query(db, "SELECT * FROM keyvalues WHERE key = $1;", 'plugin-name');
+  let results = sql.query(db, "SELECT * FROM keyvalues WHERE key = @p1;", 'plugin-name');
   for (const row of results) {
     console.log(`key: ${row.key}, value: ${row.value}`);
   }


### PR DESCRIPTION
sp_executesql syntax needs a statement  with @P  parameters, not $1. 

Just fixing the example for MS-SQL Server 2022.

This PR fixes issue: #39 .