### PR TITLE
Updating CI in-line with latest changes in k6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Check build
         run: |
           go version
@@ -42,20 +42,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x, tip]
+        go-version: [1.20.x, 1.21.x, tip]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go ${{ matrix.go-version }}
         if: matrix.go-version != 'tip'
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install Go stable
         if: matrix.go-version == 'tip'
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.x
       - name: Install Go tip

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Check module dependencies
         run: |
           go version
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Retrieve golangci-lint version
         run: |
           echo "Version=$(head -n 1 "${GITHUB_WORKSPACE}/.golangci.yml" | tr -d '# ')" >> $GITHUB_OUTPUT

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.52.2
+# v1.55.2
 # Please don't remove the first line. It is used in CI to determine the golangci version
 run:
   deadline: 5m
@@ -25,8 +25,8 @@ issues:
         - funlen
         - lll
     - linters:
-        - paralleltest # false positive: https://github.com/kunwardeep/paralleltest/issues/8.
-      text: "does not use range value in test Run"
+        - staticcheck # Tracked in https://github.com/grafana/xk6-grpc/issues/14
+      text: "The entire proto file grpc/reflection/v1alpha/reflection.proto is marked as deprecated."
     - linters:
         - forbidigo
       text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'
@@ -69,7 +69,6 @@ linters:
     - bodyclose
     - contextcheck
     - cyclop
-    - depguard
     - dogsled
     - dupl
     - durationcheck
@@ -97,6 +96,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - interfacebloat
     - lll
     - makezero
     - misspell


### PR DESCRIPTION
Removing use of 1.19 in CI given precedent from k6-core CI changes.