### PR TITLE
Support TLS when using the Mysql driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Supported RDBMSs: `mysql`, `postgres`, `sqlite3`, `sqlserver`, `azuresql`, `clic
 directory for usage. Other RDBMSs are not supported, see
 [details below](#support-for-other-rdbmss).
 
+## Table of Contents
+- [Build](#build)
+- [Development](#development)
+- [Example](#example)
+  - [TLS support](#tls-support)
+  - [Support for other RDBMSs](#support-for-other-rdbmss)
+- [Docker](#docker)
 
 ## Build
 
@@ -116,9 +123,28 @@ default ✓ [======================================] 1 VUs  00m00.0s/10m0s  1/1 
     iterations...........: 1   15.292228/s
 ```
 
-## See also
+#### See also
 
 - [Load Testing SQL Databases with k6](https://k6.io/blog/load-testing-sql-databases-with-k6/)
+
+### TLS Support
+Presently, TLS support is available only for the MySQL driver.
+
+To enable TLS support, call `sql.loadTLS` from the script, before calling `sql.open`. [mysql_secure_test.js](examples/mysql_secure_test.js) is an example.
+
+`sql.loadTLS` accepts the following options:
+
+```javascript
+sql.loadTLS({
+  enableTLS: true,
+  insecureSkipTLSverify: true,
+  minVersion: sql.TLS_1_2,
+  // Possible values: sql.TLS_1_0, sql.TLS_1_1, sql.TLS_1_2, sql.TLS_1_3
+  caCertFile: '/filepath/to/ca.pem',
+  clientCertFile: '/filepath/to/client-cert.pem',
+  clientKeyFile: '/filepath/to/client-key.pem',
+});
+```
 
 ### Support for other RDBMSs
 

--- a/examples/mysql_secure_test.js
+++ b/examples/mysql_secure_test.js
@@ -4,7 +4,7 @@ sql.loadTLS({
   enableTLS: true,
   insecureSkipTLSverify: true,
   minVersion: sql.TLS_1_2,  
-  // Possible values: TLS_1_0, TLS_1_1, TLS_1_2, TLS_1_3
+  // Possible values: sql.TLS_1_0, sql.TLS_1_1, sql.TLS_1_2, sql.TLS_1_3
   caCertFile: 'ca.pem',
   clientCertFile: 'client-cert.pem',
   clientKeyFile: 'client-key.pem',

--- a/examples/mysql_secure_test.js
+++ b/examples/mysql_secure_test.js
@@ -1,0 +1,37 @@
+import sql from 'k6/x/sql';
+
+sql.loadTLS({
+  enableTLS: true,
+  insecureSkipTLSverify: true,
+  minVersion: sql.TLS_1_2,  
+  // Possible values: TLS_1_0, TLS_1_1, TLS_1_2, TLS_1_3
+  caCertFile: 'ca.pem',
+  clientCertFile: 'client-cert.pem',
+  clientKeyFile: 'client-key.pem',
+});
+
+const db = sql.open('mysql', 'root:password@tcp(localhost:3306)/mysql')
+
+export function setup() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS keyvalues (
+      id INT(6) UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+      \`key\` VARCHAR(50) NOT NULL,
+      value VARCHAR(50) NULL
+    );
+  `);
+}
+
+export function teardown() {
+  db.close();
+}
+
+export default function () {
+  db.exec("INSERT INTO keyvalues (`key`, value) VALUES('plugin-name', 'k6-plugin-sql');");
+
+  let results = sql.query(db, "SELECT * FROM keyvalues WHERE `key` = ?;", 'plugin-name');
+  for (const row of results) {
+    // Convert array of ASCII integers into strings. See https://github.com/grafana/xk6-sql/issues/12
+    console.log(`key: ${String.fromCharCode(...row.key)}, value: ${String.fromCharCode(...row.value)}`);
+  }
+}

--- a/sql.go
+++ b/sql.go
@@ -15,7 +15,6 @@ import (
 
 	// Blank imports required for initialization of drivers
 	_ "github.com/ClickHouse/clickhouse-go/v2"
-	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/microsoft/go-mssqldb"

--- a/sql.go
+++ b/sql.go
@@ -2,9 +2,15 @@
 package sql
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	dbsql "database/sql"
+	"encoding/json"
 	"fmt"
-
+	"github.com/go-sql-driver/mysql"
+	"github.com/grafana/sobek"
+	"os"
+	"strings"
 	// Blank imports required for initialization of drivers
 	_ "github.com/ClickHouse/clickhouse-go/v2"
 	_ "github.com/go-sql-driver/mysql"
@@ -12,10 +18,23 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/azuread"
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/lib/netext"
 )
 
+// TLSVersions is a map of TLS versions to their numeric values.
+var TLSVersions map[string]uint16
+
 func init() {
+	// Initialize the TLS versions map.
+	TLSVersions = map[string]uint16{
+		netext.TLS_1_0: tls.VersionTLS10,
+		netext.TLS_1_1: tls.VersionTLS11,
+		netext.TLS_1_2: tls.VersionTLS12,
+		netext.TLS_1_3: tls.VersionTLS13,
+	}
+
 	modules.Register("k6/x/sql", new(RootModule))
 }
 
@@ -25,7 +44,9 @@ type RootModule struct{}
 
 // SQL represents an instance of the SQL module for every VU.
 type SQL struct {
-	vu modules.VU
+	vu        modules.VU
+	exports   *sobek.Object
+	tlsConfig TLSConfig
 }
 
 // Ensure the interfaces are implemented correctly.
@@ -37,13 +58,34 @@ var (
 // NewModuleInstance implements the modules.Module interface to return
 // a new instance for each VU.
 func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
-	return &SQL{vu: vu}
+	runtime := vu.Runtime()
+
+	moduleInstance := &SQL{
+		vu:        vu,
+		exports:   runtime.NewObject(),
+		tlsConfig: TLSConfig{},
+	}
+	// Export constants to the JS code.
+	moduleInstance.defineConstants()
+
+	mustExport := func(name string, value interface{}) {
+		if err := moduleInstance.exports.Set(name, value); err != nil {
+			common.Throw(runtime, err)
+		}
+	}
+	mustExport("loadTLS", moduleInstance.LoadTLS)
+	mustExport("open", moduleInstance.Open)
+	mustExport("query", moduleInstance.Query)
+
+	return moduleInstance
 }
 
 // Exports implements the modules.Instance interface and returns the exports
 // of the JS module.
 func (sql *SQL) Exports() modules.Exports {
-	return modules.Exports{Default: sql}
+	return modules.Exports{
+		Default: sql.exports,
+	}
 }
 
 // KeyValue is a simple key-value pair.
@@ -58,20 +100,113 @@ func contains(array []string, element string) bool {
 	return false
 }
 
+// defineConstants defines the constants that can be used in the JS code.
+func (sql *SQL) defineConstants() {
+	runtime := sql.vu.Runtime()
+	mustAddProp := func(name string, val interface{}) {
+		err := sql.exports.DefineDataProperty(
+			name, runtime.ToValue(val), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE,
+		)
+		if err != nil {
+			common.Throw(runtime, err)
+		}
+	}
+
+	// TLS versions
+	mustAddProp("TLS_1_0", netext.TLS_1_0)
+	mustAddProp("TLS_1_1", netext.TLS_1_1)
+	mustAddProp("TLS_1_2", netext.TLS_1_2)
+	mustAddProp("TLS_1_3", netext.TLS_1_3)
+}
+
+type TLSConfig struct {
+	EnableTLS             bool   `json:"enableTLS"`
+	InsecureSkipTLSverify bool   `json:"insecureSkipTLSverify"`
+	MinVersion            string `json:"minVersion"`
+	CAcertFile            string `json:"caCertFile"`
+	ClientCertFile        string `json:"clientCertFile"`
+	ClientKeyFile         string `json:"clientKeyFile"`
+}
+
+// LoadTLS loads the TLS configuration for the SQL module.
+func (sql *SQL) LoadTLS(params map[string]interface{}) {
+	runtime := sql.vu.Runtime()
+	var tlsConfig *TLSConfig
+	if b, err := json.Marshal(params); err != nil {
+		common.Throw(runtime, err)
+	} else {
+		if err := json.Unmarshal(b, &tlsConfig); err != nil {
+			common.Throw(runtime, err)
+		}
+	}
+	sql.tlsConfig = *tlsConfig
+}
+
 // Open establishes a connection to the specified database type using
 // the provided connection string.
-func (*SQL) Open(database string, connectionString string) (*dbsql.DB, error) {
+func (sql *SQL) Open(database string, connectionString string) (*dbsql.DB, error) {
 	supportedDatabases := []string{"mysql", "postgres", "sqlite3", "sqlserver", "azuresql", "clickhouse"}
 	if !contains(supportedDatabases, database) {
 		return nil, fmt.Errorf("database %s is not supported", database)
+	}
+
+	if database == "mysql" && sql.tlsConfig.EnableTLS {
+		tlsConfigKey := "custom"
+		if err := registerTLS(tlsConfigKey, sql.tlsConfig); err != nil {
+			return nil, err
+		}
+		connectionString = prefixConnectionString(connectionString, tlsConfigKey)
 	}
 
 	db, err := dbsql.Open(database, connectionString)
 	if err != nil {
 		return nil, err
 	}
-
 	return db, nil
+}
+
+// prefixConnectionString prefixes the connection string with the TLS configuration key.
+func prefixConnectionString(connectionString string, tlsConfigKey string) string {
+	var separator string
+	if strings.Contains(connectionString, "?") {
+		separator = "&"
+	} else {
+		separator = "?"
+	}
+	return fmt.Sprintf("%s%stls=%s", connectionString, separator, tlsConfigKey)
+}
+
+// registerTLS loads the ca-cert and registers the TLS configuration with the MySQL driver.
+func registerTLS(tlsConfigKey string, tlsConfig TLSConfig) error {
+	rootCAs := x509.NewCertPool()
+	{
+		pem, err := os.ReadFile(tlsConfig.CAcertFile)
+		if err != nil {
+			return err
+		}
+		if ok := rootCAs.AppendCertsFromPEM(pem); !ok {
+			return fmt.Errorf("failed to append PEM")
+		}
+	}
+	clientCerts := make([]tls.Certificate, 0, 1)
+	{
+		certs, err := tls.LoadX509KeyPair(tlsConfig.ClientCertFile, tlsConfig.ClientKeyFile)
+		if err != nil {
+			return err
+		}
+		clientCerts = append(clientCerts, certs)
+	}
+
+	mysqlTLSConfig := &tls.Config{
+		RootCAs:            rootCAs,
+		Certificates:       clientCerts,
+		MinVersion:         TLSVersions[tlsConfig.MinVersion],
+		InsecureSkipVerify: tlsConfig.InsecureSkipTLSverify,
+	}
+	if err := mysql.RegisterTLSConfig(tlsConfigKey, mysqlTLSConfig); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Query executes the provided query string against the database, while

--- a/sql_test.go
+++ b/sql_test.go
@@ -99,7 +99,7 @@ func setupTestEnv(t *testing.T) *sobek.Runtime {
 func TestPrefixConnectionString(t *testing.T) {
 	t.Parallel()
 
-	var testCases = []struct {
+	testCases := []struct {
 		name             string
 		connectionString string
 		want             string
@@ -118,6 +118,11 @@ func TestPrefixConnectionString(t *testing.T) {
 			name:             "WithExistingTLSparam",
 			connectionString: "root:password@tcp(localhost:3306)/mysql?tls=custom",
 			want:             "root:password@tcp(localhost:3306)/mysql?tls=custom",
+		},
+		{
+			name:             "WithExistingTLSparam",
+			connectionString: "root:password@tcp(localhost:3306)/mysql?tls=notcustom",
+			want:             "root:password@tcp(localhost:3306)/mysql?tls=notcustom&tls=custom",
 		},
 	}
 

--- a/sql_test.go
+++ b/sql_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grafana/sobek"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modulestest"
@@ -93,4 +94,39 @@ func setupTestEnv(t *testing.T) *sobek.Runtime {
 	require.NoError(t, rt.Set("sql", m.Exports().Default))
 
 	return rt
+}
+
+func TestPrefixConnectionString(t *testing.T) {
+	t.Parallel()
+
+	var testCases = []struct {
+		name             string
+		connectionString string
+		want             string
+	}{
+		{
+			name:             "HappyPath",
+			connectionString: "root:password@tcp(localhost:3306)/mysql",
+			want:             "root:password@tcp(localhost:3306)/mysql?tls=custom",
+		},
+		{
+			name:             "WithExistingParams",
+			connectionString: "root:password@tcp(localhost:3306)/mysql?param=value",
+			want:             "root:password@tcp(localhost:3306)/mysql?param=value&tls=custom",
+		},
+		{
+			name:             "WithExistingTLSparam",
+			connectionString: "root:password@tcp(localhost:3306)/mysql?tls=custom",
+			want:             "root:password@tcp(localhost:3306)/mysql?tls=custom",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := prefixConnectionString(tc.connectionString, "custom")
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
Extended xk6-sql to support mysql connection over TLS.

## Details
The mysql driver already supports TLS. These are additions to make xk6-sql TLS aware; such that, the TLS settings can be passed to the underlying drivers.  

> [!NOTE]  
> 1. No changes are required for the existing scripts. The `open` interface is retained as-is.
> 2. TLS is registered only if `enableTLS: true` is passed to `loadTLS` 


## Testing Done
```
./k6 run examples/mysql_secure_test.js -v
DEBU[0000] Logger format: TEXT                          
DEBU[0000] k6 version: v0.51.0 (commit/a3010c8ad2-dirty, go1.22.6, darwin/arm64) 

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

DEBU[0000] Resolving and reading test 'examples/mysql_secure_test.js'... 
DEBU[0000] Loading...                                    moduleSpecifier="file:///<redacted>/xk6-sql/examples/mysql_secure_test.js" originalModuleSpecifier=examples/mysql_secure_test.js
DEBU[0000] 'examples/mysql_secure_test.js' resolved to 'file:///<redacted>/code/xk6-sql/examples/mysql_secure_test.js' and successfully loaded 1141 bytes! 
DEBU[0000] Gathering k6 runtime options...              
DEBU[0000] Initializing k6 runner for 'examples/mysql_secure_test.js' (file:///<redacted>/code/xk6-sql/examples/mysql_secure_test.js)... 
DEBU[0000] Detecting test type for...                    test_path="file:///<redacted>/code/xk6-sql/examples/mysql_secure_test.js"
DEBU[0000] Trying to load as a JS test...                test_path="file:///<redacted>/code/xk6-sql/examples/mysql_secure_test.js"
DEBU[0000] Babel: Transformed                            t=40.119292ms
DEBU[0000] Runner successfully initialized!             
DEBU[0000] Parsing CLI flags...                         
DEBU[0000] Consolidating config layers...               
DEBU[0000] Parsing thresholds and validating config...  
DEBU[0000] Initializing the execution scheduler...      
DEBU[0000] Starting 2 outputs...                         component=output-manager
DEBU[0000] Starting...                                   component=metrics-engine-ingester
DEBU[0000] Started!                                      component=metrics-engine-ingester
     execution: local
        script: examples/mysql_secure_test.js
        output: -

     scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
              * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)

DEBU[0000] Trapping interrupt signals so k6 can handle them gracefully... 
DEBU[0000] Starting emission of VUs and VUsMax metrics... 
DEBU[0000] Start of initialization                       executorsCount=1 neededVUs=1 phase=execution-scheduler-init
DEBU[0000] Starting the REST API server on localhost:6565 
DEBU[0000] Initialized VU #1                             phase=execution-scheduler-init
DEBU[0000] Finished initializing needed VUs, start initializing executors...  phase=execution-scheduler-init
DEBU[0000] Initialized executor default                  phase=execution-scheduler-init
DEBU[0000] Initialization completed                      phase=execution-scheduler-init
DEBU[0000] Start of test run                             executorsCount=1 phase=execution-scheduler-run
DEBU[0000] Running setup()...                           
DEBU[0000] Start all executors...                        phase=execution-scheduler-run
DEBU[0000] Starting executor                             executor=default startTime=0s type=per-vu-iterations
DEBU[0000] Starting executor run...                      executor=per-vu-iterations iterations=1 maxDuration=10m0s scenario=default type=per-vu-iterations vus=1
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
INFO[0000] key: plugin-name, value: k6-plugin-sql        source=console
DEBU[0000] Regular duration is done, waiting for iterations to gracefully finish  executor=per-vu-iterations gracefulStop=30s scenario=default
DEBU[0000] Executor finished successfully                executor=default startTime=0s type=per-vu-iterations
DEBU[0000] Running teardown()...                        
DEBU[0000] Test finished cleanly                        
DEBU[0000] Stopping vus and vux_max metrics emission...  phase=execution-scheduler-init
DEBU[0000] Metrics emission of VUs and VUsMax metrics stopped 
DEBU[0000] Releasing signal trap...                     
DEBU[0000] Sending usage report...                      
DEBU[0000] Waiting for metrics and traces processing to finish... 
DEBU[0000] Metrics and traces processing finished!      
DEBU[0000] Stopping outputs...                          
DEBU[0000] Stopping 2 outputs...                         component=output-manager
DEBU[0000] Stopping...                                   component=metrics-engine-ingester
DEBU[0000] Stopped!                                      component=metrics-engine-ingester
DEBU[0000] Generating the end-of-test summary...        

     data_received........: 0 B 0 B/s
     data_sent............: 0 B 0 B/s
     iteration_duration...: avg=9.11ms min=6.87µs med=13.57ms max=13.75ms p(90)=13.72ms p(95)=13.74ms
     iterations...........: 1   26.986911/s


running (00m00.0s), 0/1 VUs, 1 complete and 0 interrupted iterations
default ✓ [======================================] 1 VUs  00m00.0s/10m0s  1/1 iters, 1 per VU
DEBU[0000] Usage report sent successfully               
DEBU[0000] Everything has finished, exiting k6 normally! 
```