### PR TITLE
use Release workflow from grafana/k6-extension-workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  release:
+    name: Release
+    uses: grafana/k6-extension-workflows/.github/workflows/release.yml@v0.2.0
+    with:
+      cgo: true
+      with: |
+        github.com/grafana/xk6-sql-driver-ramsql
+        github.com/grafana/xk6-sql-driver-sqlite3
+        github.com/grafana/xk6-sql-driver-mysql
+        github.com/grafana/xk6-sql-driver-postgres


### PR DESCRIPTION
Use the Release workflow from the [grafana/k6-extension-workflows](https://github.com/grafana/k6-extension-workflows ) repository to attach release artifact (precompiled k6 binaries) to releases.