### PR TITLE
Add smoke test

### DIFF
--- a/releases/v1.0.1.md
+++ b/releases/v1.0.1.md
@@ -1,0 +1,5 @@
+xk6-sql `v1.0.1` is here 🎉!
+
+This release includes:
+
+- A `smoke.test.js` file has been added for smoke testing after the build. The `k6lint`'s `smoke` checker expects a smoke test file.

--- a/smoke.test.ts
+++ b/smoke.test.ts
@@ -1,0 +1,3 @@
+import "k6/x/sql";
+
+export default function () {}


### PR DESCRIPTION
A `smoke.test.js` file has been added for smoke testing after the build. The `k6lint`'s `smoke` checker expects a smoke test file.
