### PR TITLE
Symbol type driver parameter support

### DIFF
--- a/releases/v1.0.3.md
+++ b/releases/v1.0.3.md
@@ -1,0 +1,7 @@
+xk6-sql `v1.0.3` is here 🎉!
+
+This release includes:
+
+Bugfixes:
+
+- [Symbol type driver parameter support](https://github.com/grafana/xk6-sql/issues/120): The `open()` function now accepts `Symbol` (class) type driver ids in addition to the primitive symbol type. This is because when a driver is imported with the `require()` function, it is not a primitive symbol that is imported, but a `Symbol` class type. Also fixes [#115](https://github.com/grafana/xk6-sql/issues/115)

--- a/sql/module_internal_test.go
+++ b/sql/module_internal_test.go
@@ -1,0 +1,33 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/grafana/sobek"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_asSymbol(t *testing.T) {
+	t.Parallel()
+
+	symbol := sobek.NewSymbol("foo")
+
+	sym, ok := asSymbol(symbol)
+
+	require.True(t, ok)
+	require.Same(t, symbol, sym)
+
+	rt := sobek.New()
+
+	obj := symbol.ToObject(rt)
+
+	sym, ok = asSymbol(obj)
+
+	require.True(t, ok)
+	require.Same(t, symbol, sym)
+
+	sym, ok = asSymbol(sobek.Undefined())
+
+	require.False(t, ok)
+	require.Nil(t, sym)
+}


### PR DESCRIPTION
[Symbol type driver parameter support](https://github.com/grafana/xk6-sql/issues/120): The `open()` function now accepts `Symbol` (class) type driver ids in addition to the primitive symbol type. This is because when a driver is imported with the `require()` function, it is not a primitive symbol that is imported, but a `Symbol` class type. Also fixes [#115](https://github.com/grafana/xk6-sql/issues/115)
