### PR TITLE
fix: use vu Context() instead of background Context

### DIFF
--- a/releases/v1.0.4.md
+++ b/releases/v1.0.4.md
@@ -1,0 +1,10 @@
+xk6-sql `v1.0.4` is here 🎉!
+
+This release includes:
+
+## Bugfixes
+
+- [Use VU Context()](https://github.com/grafana/xk6-sql/issues/124): VU Context() is now used in `query()` and `exec()` functions instead of background context. Using background context is a potential problem if SQL operations are still running after the VU context is invalidated.
+
+
+

--- a/sql/sql_internal_test.go
+++ b/sql/sql_internal_test.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/grafana/sobek"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modulestest"
 )
 
 func TestOpen(t *testing.T) { //nolint: paralleltest
-	mod, ok := New().NewModuleInstance(nil).(*module)
+	rt := modulestest.NewRuntime(t)
+
+	mod, ok := New().NewModuleInstance(rt.VU).(*module)
 
 	require.True(t, ok)
 


### PR DESCRIPTION
VU Context() is now used in `query()` and `exec()` functions instead of background context. Using background context is a potential problem if SQL operations are still running after the VU context is invalidated.